### PR TITLE
links fixed in table of content

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,9 @@
 
 ## Table of contents
 
-<p align = "left">
-<a href="https://github.com/nlkguy/archer-t2u-plus-linux#driver-for-debian-based-linux-distros-ubuntukali-linuxx86_64"> 1) Driver for Debian Based Linux Distros (Ubuntu/Kali Linux)(x86_64 </a> <br>
-  <a href="https://github.com/nlkguy/archer-t2u-plus-linux#driver-for-debian-based-linux-distros-ubuntukali-linuxx86_64"> 2) Driver for Raspberry Pi (Raspbian OS / Kali)(ARM)</a><br>
-  <a href="https://github.com/nlkguy/archer-t2u-plus-linux#uninstall-driver-in-linux"> 3) Uninstall Driver in Linux</a>
-</p>
+1. <a href="https://github.com/nlkguy/archer-t2u-plus-linux#driver-for-debian-based-linux-distros-ubuntukali-linuxx86_64">Driver for Debian Based Linux Distros (Ubuntu/Kali Linux)(x86_64) </a>
+1. <a href="https://github.com/nlkguy/archer-t2u-plus-linux#driver-for-debian-based-linux-distros-ubuntukali-linuxx86_64">Driver for Raspberry Pi (Raspbian OS / Kali)(ARM)</a>
+1. <a href="https://github.com/nlkguy/archer-t2u-plus-linux#uninstall-driver-in-linux">Uninstall Driver in Linux</a>
 
 TP-Link Archer T2U Plus a.k.a AC600 High Gain is a very **affordable** dual band wireless adapter **compatible with kali linux** and supports monitor mode , soft AP mode,packet injection etc. it supports both 2.4 GHz and 5GHz band and has a 5dBi Antenna for better signal reception. 2357:0120
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 ## Table of contents
 
-1. <a href="https://github.com/nlkguy/archer-t2u-plus-linux#driver-for-debian-based-linux-distros-ubuntukali-linuxx86_64">Driver for Debian Based Linux Distros (Ubuntu/Kali Linux)(x86_64) </a>
-1. <a href="https://github.com/nlkguy/archer-t2u-plus-linux#driver-for-debian-based-linux-distros-ubuntukali-linuxx86_64">Driver for Raspberry Pi (Raspbian OS / Kali)(ARM)</a>
-1. <a href="https://github.com/nlkguy/archer-t2u-plus-linux#uninstall-driver-in-linux">Uninstall Driver in Linux</a>
+1. <a href="https://github.com/Krishak15/archer-t2u-plus-linux#driver-for-debian-based-linux-distros-ubuntukali-linuxx86_64">Driver for Debian Based Linux Distros (Ubuntu/Kali Linux)(x86_64) </a>
+1. <a href="https://github.com/Krishak15/archer-t2u-plus-linux#driver-for-raspberry-pi-raspbian-os--kaliarm">Driver for Raspberry Pi (Raspbian OS / Kali)(ARM)</a>
+1. <a href="https://github.com/Krishak15/archer-t2u-plus-linux#uninstall-driver-in-linux">Uninstall Driver in Linux</a>
 
 TP-Link Archer T2U Plus a.k.a AC600 High Gain is a very **affordable** dual band wireless adapter **compatible with kali linux** and supports monitor mode , soft AP mode,packet injection etc. it supports both 2.4 GHz and 5GHz band and has a 5dBi Antenna for better signal reception. 2357:0120
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 ## Table of contents
 
 <p align = "left">
-<a href="https://github.com/Krishak15/archer-t2u-plus-linux/edit/main/README.md#driver-for-debian-based-linux-distros-ubuntukali-linuxx86_64"> 1) Driver for Debian Based Linux Distros (Ubuntu/Kali Linux)(x86_64 </a> <br>
-  <a href="https://github.com/Krishak15/archer-t2u-plus-linux/edit/main/README.md#driver-for-raspberry-pi-raspbian-os--kaliarm"> 2) Driver for Raspberry Pi (Raspbian OS / Kali)(ARM)</a><br>
-  <a href="https://github.com/Krishak15/archer-t2u-plus-linux/edit/main/README.md#uninstall-driver-in-linux"> 3) Uninstall Driver in Linux</a>
+<a href="https://github.com/nlkguy/archer-t2u-plus-linux#driver-for-debian-based-linux-distros-ubuntukali-linuxx86_64"> 1) Driver for Debian Based Linux Distros (Ubuntu/Kali Linux)(x86_64 </a> <br>
+  <a href="https://github.com/nlkguy/archer-t2u-plus-linux#driver-for-debian-based-linux-distros-ubuntukali-linuxx86_64"> 2) Driver for Raspberry Pi (Raspbian OS / Kali)(ARM)</a><br>
+  <a href="https://github.com/nlkguy/archer-t2u-plus-linux#uninstall-driver-in-linux"> 3) Uninstall Driver in Linux</a>
 </p>
 
 TP-Link Archer T2U Plus a.k.a AC600 High Gain is a very **affordable** dual band wireless adapter **compatible with kali linux** and supports monitor mode , soft AP mode,packet injection etc. it supports both 2.4 GHz and 5GHz band and has a 5dBi Antenna for better signal reception. 2357:0120


### PR DESCRIPTION
### Table of content (toc) links fixed

_details_ 

Previous link in table of content items linked to edit the readme. In case user as not logged into github, this redirected to github log in page. In case users are logged into github, this redirected to "fork the repo" page.

---

Example:

The previous toc item "_Driver for Debian Based Linux Distros (Ubuntu/Kali Linux)(x86_64_" linked to 
```
https://github.com/Krishak15/archer-t2u-plus-linux/edit/main/README.md#driver-for-debian-based-linux-distros-ubuntukali-linuxx86_64
``` 

where as I assume it should link to 

```
https://github.com/nlkguy/archer-t2u-plus-linux#driver-for-debian-based-linux-distros-ubuntukali-linuxx86_64
```